### PR TITLE
Explicitly add global RX permission to shell scripts at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,16 @@ ENV LAMBDA_RUNTIME_DIR=/var/runtime
 
 # add the Lambda RIE for debugging
 ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/local/bin/aws-lambda-rie
-RUN chmod +x /usr/local/bin/aws-lambda-rie
 
 COPY AWSLambdaRuntime /usr/share/WolframEngine/Applications/AWSLambdaRuntime
 
 COPY runtime-entrypoint.sh /runtime-entrypoint.sh
 COPY runtime-kernel-wrapper.sh /runtime-kernel-wrapper.sh
+
+RUN chmod a+rx \
+  /usr/local/bin/aws-lambda-rie \
+  /runtime-entrypoint.sh \
+  /runtime-kernel-wrapper.sh
 
 USER wolframengine
 


### PR DESCRIPTION
This fixes an apparently transient issue caused by missing execute permissions on these scripts at runtime.