### PR TITLE
Patch libiomp5.so in layout to work around 13.0.0 incompatibility issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,12 @@ COPY AWSLambdaRuntime /usr/share/WolframEngine/Applications/AWSLambdaRuntime
 COPY runtime-entrypoint.sh /runtime-entrypoint.sh
 COPY runtime-kernel-wrapper.sh /runtime-kernel-wrapper.sh
 
+# patch layout with libiomp5.so from WL 12.3.1, to work around OpenMP/MKL
+# incompatibility issue in 13.0.0 relating to /dev/shm not working in Lambda
+COPY --from=wolframresearch/wolframengine:12.3.1 \
+  /usr/local/Wolfram/WolframEngine/12.3/SystemFiles/Libraries/Linux-x86-64/libiomp5.so \
+  /usr/local/Wolfram/WolframEngine/13.0/SystemFiles/Libraries/Linux-x86-64/libiomp5.so
+
 RUN chmod a+rx \
   /usr/local/bin/aws-lambda-rie \
   /runtime-entrypoint.sh \


### PR DESCRIPTION
The version of Intel MKL in WL 13.0.0 has an OpenMP runtime that crashes on Lambda, apparently due to `/dev/shm` not existing in the Lambda execution environment.
```
OMP: Error #179: Function Can't open SHM2 failed:
OMP: System error #38: Function not implemented
Aborted (core dumped)
```

This patches the `libiomp5.so` DLL using the copy from 12.3.1, which doesn't have this problem.